### PR TITLE
[Style] MainView Cell의 여백밀림 현상을 수정했습니다.

### DIFF
--- a/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/Views/TheoPark/MainView.swift
+++ b/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/Views/TheoPark/MainView.swift
@@ -143,22 +143,22 @@ struct MainView: View {
                 
             }
             
-            SplashView()
-                .opacity(isLoading ? 1 : 0)
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        withAnimation(.easeInOut(duration: 1)) {
-                            self.isLoading.toggle()
-                        }
-                        
-                    }
-                }
+//            SplashView()
+//                .opacity(isLoading ? 1 : 0)
+//                .onAppear {
+//                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+//                        withAnimation(.easeInOut(duration: 1)) {
+//                            self.isLoading.toggle()
+//                        }
+//
+//                    }
+//                }
             
         }
     }
     
     var dayOffToggle: some View {
-        HStack(spacing: 16){
+        HStack(spacing: 10){
             Toggle(isOn: $toggleIsOn, label: {
                 Label("하루만 알림 끄기", systemImage: "powersleep")
                     .foregroundColor(.white)
@@ -166,7 +166,7 @@ struct MainView: View {
                 
             }).tint(.blue)
         }
-        .padding(EdgeInsets(top: 12, leading: 20, bottom: 12, trailing: 20))
+        .padding(EdgeInsets(top: 8, leading: 20, bottom: 8, trailing: 24))
     }
     
     var pleaseTurnOnTheNotiView: some View {

--- a/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/Views/TheoPark/NotificationSettingsCell.swift
+++ b/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/Views/TheoPark/NotificationSettingsCell.swift
@@ -201,7 +201,7 @@ struct NotificationSettingsCell: View {
         }
         .background(Color.init(hue: 0, saturation: 0, brightness: 0.12))
         .cornerRadius(20)
-        .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+//        .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
         .gesture(
             DragGesture(minimumDistance: 0)
                 .onEnded() {_ in


### PR DESCRIPTION
#40 #41 

### 🔖  40 41

Close #
<!-- PR과 관련된 Issue를 자동으로 닫습니다. -->

### 📙 작업 내역

(알림허용을 하지 않았을 때)의 MainView 내 NotiCell 영역의 패딩값이 2번 중복되서
요일과 여백이 약간 밀렸는데요! 1개를 제외해두었습니다.

#### 📋 체크리스트

- [ ] 이슈40과 41이 동일한 MainView에서 작업되서, #40 에서 해당 사항을 호다닥 수정 완료했습니다. 
