### PR TITLE
[HotFix] DayOffToggleButton Algorithm Fix

### DIFF
--- a/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/PushNotification/LocalNotificationManager.swift
+++ b/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/PushNotification/LocalNotificationManager.swift
@@ -182,6 +182,9 @@ extension LocalNotificationManager {
         if toggleState {
             setNextDayNotification()
         } else {
+            /// 이전 알림 예약 전체 취소
+            cancelNotification()
+            
             setLocalNotification(weekdays: weekdays, startHour: startHour, endHour: endHour, frequency: frequency)
             
         }


### PR DESCRIPTION
DailyNotiOff 토글 버튼이 비활성화되었을 때, 이전 활성화되었을 때 예약한 "알림을 다시 켰어요~" 메세지를 삭제하도록 개선했습니다.

### 🔖  Issue Number

Close #99
<!-- PR과 관련된 Issue를 자동으로 닫습니다. -->

### 📙 작업 내역

DailyNotiOff 토글 버튼이 비활성화되었을 때, 이전 활성화되었을 때 예약한 "알림을 다시 켰어요~" 메세지를 삭제하도록 개선했습니다.

#### 📋 체크리스트
