### PR TITLE
'하루만 알림끄기' 토글 활성화 이후 앱을 종료해도 값을 저장하도록 수정

### DIFF
--- a/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/Views/MainView/DailyNotiToggleRow.swift
+++ b/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/Views/MainView/DailyNotiToggleRow.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 class ToggleStateModel: ObservableObject {
-    @Published var toggleIsOn: Bool = false {
+    @Published var toggleIsOn: Bool = UserDefaults.standard.bool(forKey: "toggleIsOn") {
         didSet {
+            UserDefaults.standard.set(self.toggleIsOn, forKey: "toggleIsOn")
             if toggleIsOn {
                 self.animationPaused = true
                 grayscaleValue = 1.0
@@ -32,7 +33,7 @@ class ToggleStateModel: ObservableObject {
 struct DailyNotiToggleRow: View {
     
     @Binding var toggleIsOn: Bool
-
+    
     var body: some View {
         HStack(spacing: 10){
             Toggle(isOn: $toggleIsOn, label: {

--- a/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/Views/MainView/MainView.swift
+++ b/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/Views/MainView/MainView.swift
@@ -64,7 +64,7 @@ struct MainView: View {
             
             checkIfFirstInApp()
             
-            self.toggleState.toggleIsOn = UserDefaults.standard.bool(forKey: "dayOffToggleState")
+            self.toggleState.toggleIsOn = UserDefaults.standard.bool(forKey: "toggleIsOn")
 
              for weekday in settings.selectedDays {
                  let index = settings.selectedDays.firstIndex(of: weekday)


### PR DESCRIPTION
ToggleStateModel 클래스 UserDefaults 추가해서 토글 상태를 저장하고 불러오는 메소드를 추가했습니다.

### 🔖  Issue Number

Close #119 
<!-- PR과 관련된 Issue를 자동으로 닫습니다. -->

### 📙 작업 내역

<!-- 구현 내용 및 작업 했던 내역을 적어주세요. -->
<!-- Issue의 Tasks 항목들을 그대로 적어주셔도 좋아요. -->

#### 📋 체크리스트

- [ ]  머지하는 브랜치를 다시 한 번 확인해주세요!
