### PR TITLE
[Feat] 시작/종료 알림 멘트를 추가했습니다.

### DIFF
--- a/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/AppDelegate.swift
+++ b/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/AppDelegate.swift
@@ -68,7 +68,7 @@ private func switchAuthorizationStatus() {
     UNUserNotificationCenter.current().getNotificationSettings { (settings) in
      
         switch settings.authorizationStatus {
-     
+    
         case .notDetermined:
             print("Authorization not determined.")
             

--- a/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/PushNotification/LocalNotificationManager.swift
+++ b/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/PushNotification/LocalNotificationManager.swift
@@ -7,14 +7,12 @@
 import SwiftUI
 import UserNotifications
 class LocalNotificationManager: NSObject, ObservableObject, UNUserNotificationCenterDelegate {
-    
     @Published var isAuthorizationRequested: Bool = false
     
     private let calendar = Calendar.current
     private let notificationCenter = UNUserNotificationCenter.current()
     private let notificationContent = UNMutableNotificationContent()
-    private let notificationTitle = NotificationTitle().variations
-    
+    private let notificationTitle = NotificationTitle()
     
     // MARK: - Request Notification Permission (Method)
     /// 시스템상의 알림 허용을 요청합니다.
@@ -26,8 +24,6 @@ class LocalNotificationManager: NSObject, ObservableObject, UNUserNotificationCe
         }
     }
 }
-
-
 
 // MARK: - 사용자 설정 알림 관련
 extension LocalNotificationManager {
@@ -46,7 +42,6 @@ extension LocalNotificationManager {
             endHour: endHour,
             frequency: frequency)
     }
-    
     
     // MARK: - Request Weekday Trigger (Method)
     /// 요일별 푸시 알림 예약을 생성하고 알림을 요청합니다.
@@ -77,7 +72,11 @@ extension LocalNotificationManager {
                 /// startHour에서 증가하는 인터벌 알림 예약 생성 및 요청
                 for count in 1...(endHour - startHour) + 1 { // 알림의 반복 횟수
                     
-                    makeNotificationContent(with: notificationTitle)
+                    /// 시작, 종료, 일반 알림 멘트 분기 처리
+                    switchNotificationContent(
+                        count: count,
+                        endCount: (endHour - startHour) + 1
+                    )
                     
                     let hour = startHour + (count - 1)
                     let minute = 0
@@ -97,12 +96,15 @@ extension LocalNotificationManager {
                     self.notificationCenter.add(request)
                 }
                 
-                
             case .twoHour:
                 /// startHour에서 증가하는 인터벌 알림 예약 생성 및 요청
                 for count in 1...((endHour - startHour) / 2) + 1 { // 알림의 반복 횟수
                     
-                    makeNotificationContent(with: notificationTitle)
+                    /// 시작, 종료, 일반 알림 멘트 분기 처리
+                    switchNotificationContent(
+                        count: count,
+                        endCount: ((endHour - startHour) / 2) + 1
+                    )
                     
                     let hour = startHour + ((count - 1) * 2)
                     let minute = 0
@@ -126,7 +128,11 @@ extension LocalNotificationManager {
                 /// startHour에서 증가하는 인터벌 알림 예약 생성 및 요청
                 for count in 1...((endHour - startHour) / 3) + 1 { // 알림의 반복 횟수
                     
-                    makeNotificationContent(with: notificationTitle)
+                    /// 시작, 종료, 일반 알림 멘트 분기 처리
+                    switchNotificationContent(
+                        count: count,
+                        endCount: ((endHour - startHour) / 3) + 1
+                    )
                     
                     let hour = startHour + ((count - 1) * 3)
                     let minute = 0
@@ -146,7 +152,6 @@ extension LocalNotificationManager {
                     self.notificationCenter.add(request)
                 }
             }
-            
         }
         /// 요청된 알림 확인
         notificationCenter.getPendingNotificationRequests { messages in
@@ -160,10 +165,20 @@ extension LocalNotificationManager {
         UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
     }
     
-    
     // MARK: - NotificationCenter Init (Method)
     private func initNotificationCenter() {
         notificationCenter.delegate = self
+    }
+    
+    // MARK: - Swich Notification Content (Method)
+    public func switchNotificationContent(count: Int, endCount: Int) {
+        if count == 1 {
+            makeNotificationContent(with: notificationTitle.openingVariations)
+        } else if count == endCount {
+            makeNotificationContent(with: notificationTitle.closingVariations)
+        } else {
+            makeNotificationContent(with: notificationTitle.basicVariations)
+        }
     }
     
     // MARK: - Notification Content (Method)
@@ -175,7 +190,6 @@ extension LocalNotificationManager {
         notificationContent.sound = UNNotificationSound.default
     }
 }
-
 
 
 // MARK: - 하루 휴식 알림 관련
@@ -194,9 +208,8 @@ extension LocalNotificationManager {
         } else {
             /// 이전 알림 예약 전체 취소
             cancelNotification()
-            
+            /// 설정알림 생성
             setLocalNotification(weekdays: weekdays, startHour: startHour, endHour: endHour, frequency: frequency)
-            
         }
     }
     

--- a/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/PushNotification/NotificationTitle.swift
+++ b/ChuckchuDrivenDevelopment/ChuckchuDrivenDevelopment/PushNotification/NotificationTitle.swift
@@ -10,10 +10,15 @@ import Foundation
 struct NotificationTitle {
     
     let openingVariations: [String] = [
+        String(localized: "Ta-da! Shall we start with good posture again today?"),
+        String(localized: "Let's start working on a brand new day with good posture! 🚀"),
+        String(localized: "Good morning! Let's start energetically. Maintain proper posture in front of the monitor! 💪"),
+        String(localized: "Start a wonderful day with a good posture 🌞"),
+        String(localized: "Shall we run through today with good posture? 🏃‍♂️🐢"),
         String(localized: "Another lively day today! I'll give you strength! 🐢")
     ]
     
-    let variations: [String] = [
+    let basicVariations: [String] = [
         String(localized: "Knock-knock, it's the spine fairy 🧚"),
         String(localized: "I'm naturally a turtle neck, but what about you… 🐢"),
         String(localized: "Save on back surgery costs with just one stretch! 💸"),
@@ -45,12 +50,13 @@ struct NotificationTitle {
         String(localized: "They say 10 seconds of good posture can change 10 years 😘"),
         String(localized: "Good posture takes responsibility for spinal health! 💪"),
         String(localized: "Master, what if your posture is worse than mine 😥")
-        
     ]
     
     let closingVariations: [String] = [
-        String(localized: "Well done! Let's meet with energy again tomorrow! 👋🏻")
-        
+        String(localized: "Well done! Let's meet with energy again tomorrow! 👋🏻"),
+        String(localized: "Healthy spine, energetic tomorrow! 🌞🌈"),
+        String(localized: "Stand tall and run towards tomorrow 🏃💨"),
+        String(localized: "Let's postpone the turtle neck to tomorrow 🐢🌙"),
+        String(localized: "Did you straighten your back? I'm going to bed now 🥱")
     ]
-    
 }

--- a/ChuckchuDrivenDevelopment/en.lproj/Localizable.strings
+++ b/ChuckchuDrivenDevelopment/en.lproj/Localizable.strings
@@ -7,6 +7,14 @@
 "Reset the notification and receive Fynn's message again.🐢" = "Reset the notification and receive Fynn's message again.🐢";
 
 //NotificationTitle.swift
+/// StartingTitles
+"Ta-da! Shall we start with good posture again today?" = "Ta-da! Shall we start with good posture again today?";
+"Let's start working on a brand new day with good posture! 🚀" = "Let's start working on a brand new day with good posture! 🚀";
+"Good morning! Let's start energetically. Maintain proper posture in front of the monitor! 💪" = "Good morning! Let's start energetically. Maintain proper posture in front of the monitor! 💪";
+"Start a wonderful day with a good posture 🌞" = "Start a wonderful day with a good posture 🌞";
+"Shall we run through today with good posture? 🏃‍♂️🐢" = "Shall we run through today with good posture? 🏃‍♂️🐢";
+"Another lively day today! I'll give you strength! 🐢" = "Another lively day today! I'll give you strength! 🐢";
+/// BasicTitles
 "Another lively day today! I'll give you strength! 🐢" = "Another lively day today! I'll give you strength! 🐢";
 "Knock-knock, it's the spine fairy 🧚" = "Knock-knock, it's the spine fairy 🧚";
 "I'm naturally a turtle neck, but what about you… 🐢" = "I'm naturally a turtle neck, but what about you… 🐢";
@@ -40,6 +48,12 @@
 "Good posture takes responsibility for spinal health! 💪" = "Good posture takes responsibility for spinal health! 💪";
 "Master, what if your posture is worse than mine 😥" = "Master, what if your posture is worse than mine 😥";
 "Well done! Let's meet with energy again tomorrow! 👋🏻" = "Well done! Let's meet with energy again tomorrow! 👋🏻";
+/// EndingTitles
+"Well done! Let's meet with energy again tomorrow! 👋🏻" = "Well done! Let's meet with energy again tomorrow! 👋🏻";
+"Healthy spine, energetic tomorrow! 🌞🌈" = "Healthy spine, energetic tomorrow! 🌞🌈";
+"Stand tall and run towards tomorrow 🏃💨" = "Stand tall and run towards tomorrow 🏃💨";
+"Let's postpone the turtle neck to tomorrow 🐢🌙" = "Let's postpone the turtle neck to tomorrow 🐢🌙";
+"Did you straighten your back? I'm going to bed now 🥱" = "Did you straighten your back? I'm going to bed now 🥱";
 
 //OnBoardingView1.swift
 "Creating Good Posture with Pin" = "Creating Good Posture with Pin";

--- a/ChuckchuDrivenDevelopment/ko.lproj/Localizable.strings
+++ b/ChuckchuDrivenDevelopment/ko.lproj/Localizable.strings
@@ -7,7 +7,14 @@
 "Reset the notification and receive Fynn's message again.🐢" = "알림을 재설정하고 다시 핀의 메세지를 받아보세요 🐢";
 
 //NotificationTitle.swift
+/// StartingTitles
+"Ta-da! Shall we start with good posture again today?" = "짜잔! 오늘도 바른자세 시작해볼까요?";
+"Let's start working on a brand new day with good posture! 🚀" = "새로운 하루! 바른 자세로 업무를 시작해봐요! 🚀";
+"Good morning! Let's start energetically. Maintain proper posture in front of the monitor! 💪" = "굿모닝! 힘차게 시작해봐요. 모니터 앞 바른자세! 💪";
+"Start a wonderful day with a good posture 🌞" = "바른 자세로 멋진 하루를 시작해봐요 🌞";
+"Shall we run through today with good posture? 🏃‍♂️🐢" = "오늘 하루도 바른자세로 달려볼까요? 🏃‍♂️🐢";
 "Another lively day today! I'll give you strength! 🐢" = "오늘도 활기찬 하루! 제가 힘을 실어드릴게요! 🐢";
+/// BasicTitles
 "Knock-knock, it's the spine fairy 🧚" = "똑똑, 척추요정 왔어요 🧚";
 "I'm naturally a turtle neck, but what about you… 🐢" = "저는 원래 거북목이지만 주인님은… 🐢";
 "Save on back surgery costs with just one stretch! 💸" = "스트레칭 한 번으로 허리 수술비 아끼기! 💸";
@@ -39,7 +46,12 @@
 "They say 10 seconds of good posture can change 10 years 😘" = "10초의 바른자세가 10년을 바꾼대요 😘";
 "Good posture takes responsibility for spinal health! 💪" = "바른 자세가 척추건강을 책임져요! 💪";
 "Master, what if your posture is worse than mine 😥" = "주인님, 저보다 거북목이면 어떡해요 😥";
+/// EndingTitles
 "Well done! Let's meet with energy again tomorrow! 👋🏻" = "수고하셨어요! 내일도 기운차게 만나요! 👋🏻";
+"Healthy spine, energetic tomorrow! 🌞🌈" = "건강한 척추, 활기찬 내일! 🌞🌈";
+"Stand tall and run towards tomorrow 🏃💨" = "어깨 펴고, 내일로 달려가요 🏃💨";
+"Let's postpone the turtle neck to tomorrow 🐢🌙" = "거북목은 내일로 미루자구요 🐢🌙";
+"Did you straighten your back? I'm going to bed now 🥱" = "허리 펴셨죠? 전 이제 자러갈게요 🥱";
 
 //OnBoardingView1.swift
 "Creating Good Posture with Pin" = "핀과 함께하는 바른 자세 만들기";


### PR DESCRIPTION
### 🔖  Issue Number

Close #123

### 📙 작업 내역

- 시작, 종료 시점 분기처리
- 각각 다섯 종류의 멘트 문자열 추가

### 📋 이 부분을 확인해주세요!
> 중점적으로 체크가 되어야 하는 기능 혹은 구체적인 코드를 짚어주세요.
- 시작과 종료 알림 멘트가 달라집니다! 멘트가 알맞게 나타나는지 확인 부탁드려요. <br/>

시작 멘트 종류:
<img width="250" alt="Screenshot 2023-09-10 at 1 57 34 PM" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team10-CenterWatch/assets/89244357/d9734f03-9449-45bc-8354-5cf020960248">

종료 멘트 종류: 
<img width="250" alt="Screenshot 2023-09-10 at 1 57 50 PM" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team10-CenterWatch/assets/89244357/0242fee3-2718-4399-89bb-dd7438d78db5">


그 외에는 일반 멘트! 
